### PR TITLE
Update and fix remote build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,9 @@ commons-compress = "1.12"
 commons-exec = "1.3"
 slf4j = "1.7.36"
 dd-plist = "1.19"
-jsch = "0.1.53"
+jsch = "2.28.2"
+# Floor required by jsch 2.28.2 (its OSGi Import-Package declares org.bouncycastle.crypto >= [1.84,2)). Bump in lockstep with jsch.
+bouncycastle = "1.84"
 jetbrains-annotations = "23.0.0"
 sqlite-jdbc = "3.8.11.2"
 ant = "1.9.16"
@@ -43,7 +45,8 @@ commons-exec = { group = "org.apache.commons", name = "commons-exec", version.re
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 dd-plist = { group = "com.googlecode.plist", name = "dd-plist", version.ref = "dd-plist" }
-jsch = { group = "com.jcraft", name = "jsch", version.ref = "jsch" }
+jsch = { group = "com.github.mwiede", name = "jsch", version.ref = "jsch" }
+bcprov-jdk18on = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
 sqlite-jdbc = { group = "org.xerial", name = "sqlite-jdbc", version.ref = "sqlite-jdbc" }
 ant = { group = "org.apache.ant", name = "ant", version.ref = "ant" }

--- a/set_version.sh
+++ b/set_version.sh
@@ -34,7 +34,7 @@ if [[ "$COMPONENT" == "moe" ]]; then
 
   WORKED=1
 
-  sed -E -i '' "s/^version += +'.+'/version = '$VERSION'/" "$MOE_CORE_DIR/build.gradle"
+  sed -E -i '' "s/^version += +\".+\"/version = \"$VERSION\"/" "$MOE_CORE_DIR/build.gradle.kts"
   sed -E -i '' "s/^MOE_VERSION=.+$/MOE_VERSION=$VERSION/" "$MOE_TOOLS_DIR/gradle.properties"
 fi
 
@@ -43,7 +43,7 @@ if [[ "$COMPONENT" == "idea" ]]; then
 
   WORKED=1
 
-  sed -E -i '' "s/^version += +'.+'/version = '$VERSION'/" "$MOE_IDEA_PLUGIN_DIR/build.gradle"
+  sed -E -i '' "s/^version += +'.+'/version = '$VERSION'/" "$MOE_IDEA_PLUGIN_DIR/build.gradle.kts"
 fi
 
 if [[ ! "$WORKED" ]]; then

--- a/tools/moe.plugin.gradle/README.md
+++ b/tools/moe.plugin.gradle/README.md
@@ -751,6 +751,9 @@ The following settings are available for configuring the remote connection:
 - `keychain.locktimeout`: keychain lock timeout in seconds, defaults to 3600.
 - `gradle.repositories`: repositories to be used when setting up the MOE SDK on the remote server, defaults to
 'mavenCentral()'.
+- `executablePaths`: comma-separated glob patterns (relative to the project root). On a **Windows build host**
+only, files whose uploaded path matches one of these are made executable on the build server. Defaults to empty.
+Ignored on macOS/Linux hosts.
 
 The identity and knownhosts keys accept special parameters to access environmental variables (`$env$KEY`),
 system properties (`$sys$KEY`) and project properties (`$proj$KEY`).

--- a/tools/moe.plugin.gradle/README.md
+++ b/tools/moe.plugin.gradle/README.md
@@ -743,7 +743,8 @@ The following settings are available for configuring the remote connection:
 - `host`: address of the remote build server.
 - `port`: port for ssh, defaults to 22.
 - `user`: user on the remote build server.
-- `identity`: path to private key.
+- `identity`: path to private key. Mutually exclusive with `agent`.
+- `agent`: use the local ssh-agent (`SSH_AUTH_SOCK`) for public-key authentication, defaults to false. Mutually exclusive with `identity`. On Windows this requires `SSH_AUTH_SOCK` to be exported (WSL / Git-Bash / MSYS2). The native Windows OpenSSH agent and PuTTY Pageant are not supported.
 - `knownhosts`: path to known_hosts file.
 - `keychain.name`: name of keychain to unlock, defaults to 'moeremotebuild.keychain'.
 - `keychain.pass`: password for keychain, defaults to ''.

--- a/tools/moe.plugin.gradle/build.gradle.kts
+++ b/tools/moe.plugin.gradle/build.gradle.kts
@@ -43,7 +43,7 @@ val POM_DEVELOPER_ORGANISATION_URL: String by project
 
 version = MOE_VERSION + (if (project.hasProperty("RELEASE")) "" else "-SNAPSHOT")
 
-javaConventions.release = 11
+javaConventions.release = 17
 
 tasks.processResources {
     val moeVer = version
@@ -87,8 +87,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(gradleTestKit())
 }
-
-tasks.test { dependsOn(":moe-sdk:devsdk") }
 
 tasks.shadowJar {
     configurations = listOf(project.configurations["shade"])
@@ -201,8 +199,17 @@ dependencies {
     testRuntimeOnly(files(createClasspathManifest))
 }
 
+val launcher = javaToolchains.launcherFor {
+    languageVersion = JavaLanguageVersion.of(javaConventions.release.get())
+}
+
+tasks.test {
+    dependsOn(":moe-sdk:devsdk")
+    systemProperty("moe.test.java_home", launcher.get().metadata.installationPath.asFile.absolutePath)
+}
+
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_11
+        jvmTarget = JvmTarget.JVM_17
     }
 }

--- a/tools/moe.plugin.gradle/build.gradle.kts
+++ b/tools/moe.plugin.gradle/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     "shade"(libs.commons.lang3)
     "shade"(libs.commons.io)
     "shade"(libs.jsch)
+    "shade"(libs.bcprov.jdk18on)
     "shade"(libs.asm)
     "shade"(libs.asm.tree)
     "shade"(libs.asm.commons)
@@ -96,6 +97,11 @@ tasks.shadowJar {
     enableAutoRelocation = true
     relocationPrefix = "org.moe.gradle.shadow"
     relocate("org.moe", "org.moe")
+    // BouncyCastle ships a signed jar; its signature files break once shaded.
+    exclude("META-INF/*.SF")
+    exclude("META-INF/*.DSA")
+    exclude("META-INF/*.RSA")
+    exclude("META-INF/*.EC")
 
     dependencies {
         exclude(dependency("org.slf4j:slf4j-api:.*"))

--- a/tools/moe.plugin.gradle/build.gradle.kts
+++ b/tools/moe.plugin.gradle/build.gradle.kts
@@ -43,6 +43,8 @@ val POM_DEVELOPER_ORGANISATION_URL: String by project
 
 version = MOE_VERSION + (if (project.hasProperty("RELEASE")) "" else "-SNAPSHOT")
 
+javaConventions.release = 11
+
 tasks.processResources {
     val moeVer = version
     inputs.property("version", moeVer)
@@ -195,6 +197,6 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_1_8
+        jvmTarget = JvmTarget.JVM_11
     }
 }

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/AbstractMoePlugin.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/AbstractMoePlugin.java
@@ -60,7 +60,7 @@ public abstract class AbstractMoePlugin implements Plugin<Project> {
     public static final String MOE = "moe";
 
     /** Required min gradle version */
-    private static final String GRADLE_MIN_VERSION = "7.1";
+    private static final String GRADLE_MIN_VERSION = "7.6.4";
 
     @NotNull
     protected final Instantiator instantiator;

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/MoePlugin.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/MoePlugin.java
@@ -59,9 +59,11 @@ import org.moe.gradle.utils.Arch;
 import org.moe.gradle.utils.PropertiesUtil;
 import org.moe.gradle.utils.Require;
 import org.moe.tools.substrate.GraalVM;
+import org.moe.tools.substrate.LocalGraalVMHost;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Optional;
@@ -128,8 +130,9 @@ public class MoePlugin extends AbstractMoePlugin {
         graalVM = project.getObjects().property(GraalVM.class);
 
         Provider<GraalVM> graalVMProvider = project.provider(() -> {
+            Path install;
             if (PropertiesUtil.tryGetProperty(project, MOE_GRAALVM_HOME_PROPERTY) != null) {
-                return new GraalVM(Paths.get(PropertiesUtil.getProperty(project, MOE_GRAALVM_HOME_PROPERTY)));
+                install = Paths.get(PropertiesUtil.getProperty(project, MOE_GRAALVM_HOME_PROPERTY));
             } else {
                 JavaToolchainService toolchains = project.getExtensions().getByType(JavaToolchainService.class);
                 JavaLauncher launcher = toolchains.launcherFor(spec -> {
@@ -137,8 +140,11 @@ public class MoePlugin extends AbstractMoePlugin {
                     spec.getVendor().set(JvmVendorSpec.GRAAL_VM);
                     spec.getImplementation().set(JvmImplementation.VENDOR_SPECIFIC);
                 }).get();
-                return new GraalVM(launcher.getExecutablePath().getAsFile().getParentFile().getParentFile().toPath());
+
+                install = launcher.getMetadata().getInstallationPath().getAsFile().toPath();
             }
+
+            return new GraalVM(GraalVM.Companion.rootJDK(install).toFile().getAbsolutePath(), new LocalGraalVMHost());
         });
 
         if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) >= 0) {

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/RemoteGraalVMHost.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/RemoteGraalVMHost.java
@@ -1,0 +1,68 @@
+package org.moe.gradle.remote;
+
+import org.jspecify.annotations.NonNull;
+import org.moe.gradle.anns.NotNull;
+import org.moe.gradle.utils.Require;
+import org.moe.tools.substrate.GraalVM;
+import org.moe.tools.substrate.GraalVMHost;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * {@link GraalVMHost} backed by an SSH {@link Server}: every operation runs on the remote macOS
+ * build server. The remote is always a Unix Mac, so paths join with '/'. Quarantine is auto-cleared
+ */
+public class RemoteGraalVMHost implements GraalVMHost {
+
+    @NotNull
+    private final Server server;
+
+    public RemoteGraalVMHost(Server server) {
+        this.server = Require.nonNull(server);
+    }
+
+    @Override
+    public boolean isWindows() {
+        return false;
+    }
+
+    @Override
+    public boolean isMac() {
+        return true;
+    }
+
+    @Override
+    public @NonNull String resolve(@NonNull String base, String... parts) {
+        final StringBuilder sb = new StringBuilder(base);
+        for (String part : parts)
+            sb.append('/').append(part);
+        return sb.toString();
+    }
+
+    @Override
+    public boolean exists(@NonNull String path) {
+        try {
+            server.exec("graalvm exists", "test -e " + quote(path));
+            return true;
+        } catch (ServerChannelException e) {
+            return false;
+        }
+    }
+
+
+    @Override
+    public @NonNull String exec(String @NonNull ... command) {
+        String cmd = Arrays.stream(command).map(RemoteGraalVMHost::quote).collect(Collectors.joining(" "));
+        return server.exec("graalvm exec", cmd);
+    }
+
+    @Override
+    public void ensureUnquarantined(@NonNull String home) {
+        server.exec("graalvm dequarantine", "xattr -r -d " + GraalVM.MAC_ATTR_COM_APPLE_QUARANTINE + " " + quote(home));
+    }
+
+    private static String quote(String s) {
+        return "'" + s.replace("'", "'\\''") + "'";
+    }
+}

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/RemoteGraalVMHost.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/RemoteGraalVMHost.java
@@ -59,6 +59,7 @@ public class RemoteGraalVMHost implements GraalVMHost {
 
     @Override
     public void ensureUnquarantined(@NonNull String home) {
+        server.exec("graalvm write-perm", "chmod -R u+w " + quote(home));
         server.exec("graalvm dequarantine", "xattr -r -d " + GraalVM.MAC_ATTR_COM_APPLE_QUARANTINE + " " + quote(home));
     }
 

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/Server.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/Server.java
@@ -21,7 +21,6 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.gradle.BuildResult;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -33,6 +32,7 @@ import org.moe.gradle.MoeSDK;
 import org.moe.gradle.anns.NotNull;
 import org.moe.gradle.anns.Nullable;
 import org.moe.gradle.groovy.closures.ConfigurationClosure;
+import org.moe.gradle.remote.file.ExecPolicy;
 import org.moe.gradle.remote.file.FileList;
 import org.moe.gradle.utils.Require;
 import org.moe.tools.substrate.GraalVM;
@@ -44,6 +44,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -120,6 +121,12 @@ public class Server {
     @Nullable
     public File getGraalVMHomeSetting() {
         return settings.getGraalVMHome();
+    }
+
+    /** Glob patterns (`moe.remotebuild.executablePaths`) to force-mark executable on the build server. */
+    @NotNull
+    public List<String> getExecutablePathsSetting() {
+        return settings.getExecutablePaths();
     }
 
     @Nullable
@@ -243,11 +250,9 @@ public class Server {
         final MoeSDK sdk = plugin.getSDK();
         try {
             final FileList list = new FileList(sdk.getRoot().getParentFile(), new URI("file://" + getUserHome() + "/").resolve(".moe-remote-sdk"));
+            list.setExecPolicy(ExecPolicy.ALL);
             final String remoteGradlewZip = list.add(sdk.getRoot());
             upload("upload sdk", list);
-            // Since zip's can't hold executable info, we need to apply it afterwards. Maybe we can be more selective if we want
-            // Or do it in ServerFileUploader, just making the files executable that also are locally
-            exec("make executable", "chmod -R +x " + list.getTarget().getPath());
             sdkDir = new URI("file://" + remoteGradlewZip);
         } catch (URISyntaxException e) {
             throw new GradleException(e.getMessage(), e);
@@ -266,9 +271,9 @@ public class Server {
 
         try {
             final FileList list = new FileList(localGraal.getParentFile(), new URI("file://" + getUserHome() + "/").resolve(".moe-remote-graal"));
+            list.setExecPolicy(ExecPolicy.ALL);
             String remoteGraalDir = list.add(localGraal);
             upload("upload graal", list);
-            exec("make executable", "chmod -R +x " + list.getTarget().getPath());
             try {
                 remoteGraalVM = new GraalVM(remoteGraalDir, new RemoteGraalVMHost(this));
             } catch (Exception e) {

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/Server.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/Server.java
@@ -35,6 +35,7 @@ import org.moe.gradle.anns.Nullable;
 import org.moe.gradle.groovy.closures.ConfigurationClosure;
 import org.moe.gradle.remote.file.FileList;
 import org.moe.gradle.utils.Require;
+import org.moe.tools.substrate.GraalVM;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -105,6 +106,20 @@ public class Server {
     @NotNull
     public boolean isRemoteAARCH64() {
         return Require.nonNull(remoteAARCH64);
+    }
+
+    @Nullable
+    private GraalVM remoteGraalVM;
+
+    @NotNull
+    public GraalVM getRemoteGraalVM() {
+        return Require.nonNull(remoteGraalVM);
+    }
+
+    /** The configured remote GraalVM home (`moe.remotebuild.graalvm.home`), available at config time; null if unset. */
+    @Nullable
+    public File getGraalVMHomeSetting() {
+        return settings.getGraalVMHome();
     }
 
     @Nullable
@@ -214,6 +229,7 @@ public class Server {
                 setupUserHome();
                 setupBuildDir();
                 prepareServerMOE();
+                prepareServerGraalVM();
             });
         });
     }
@@ -226,7 +242,7 @@ public class Server {
     private void prepareServerMOE() {
         final MoeSDK sdk = plugin.getSDK();
         try {
-            final FileList list = new FileList(sdk.getRoot().getParentFile(), new URI("file://" + getUserHome() + "/").resolve(".moe-remote"));
+            final FileList list = new FileList(sdk.getRoot().getParentFile(), new URI("file://" + getUserHome() + "/").resolve(".moe-remote-sdk"));
             final String remoteGradlewZip = list.add(sdk.getRoot());
             upload("upload sdk", list);
             // Since zip's can't hold executable info, we need to apply it afterwards. Maybe we can be more selective if we want
@@ -238,6 +254,32 @@ public class Server {
         }
 
         exec("check MOE SDK path", "[ -d '" + sdkDir.getPath() + "' ]");
+    }
+
+    private void prepareServerGraalVM() {
+        final File localGraal = settings.getGraalVMHome();
+        if (localGraal == null || !localGraal.exists() || !localGraal.isDirectory()) {
+            throw new GradleException("Remote build requires a GraalVM for the build server: set "
+                    + "'moe.remotebuild.graalvm.home' to the path of a Java " + GraalVM.SUPPORTED_JAVA_MAJOR
+                    + " GraalVM home on the host, targetting the build server.");
+        }
+
+        try {
+            final FileList list = new FileList(localGraal.getParentFile(), new URI("file://" + getUserHome() + "/").resolve(".moe-remote-graal"));
+            String remoteGraalDir = list.add(localGraal);
+            upload("upload graal", list);
+            exec("make executable", "chmod -R +x " + list.getTarget().getPath());
+            try {
+                remoteGraalVM = new GraalVM(remoteGraalDir, new RemoteGraalVMHost(this));
+            } catch (Exception e) {
+                throw new GradleException("Remote graal '" + remoteGraalDir + "' broken on build host", e);
+            }
+        } catch (Exception e) {
+            throw new GradleException("Failed to deploy graalvm '" + localGraal.getAbsolutePath() + "' to build host", e);
+        }
+
+        exec("check MOE SDK path", "[ -d '" + remoteGraalVM.getHome() + "' ]");
+        LOG.quiet("MOE Remote Build - REMOTE_GRAALVM=" + remoteGraalVM.getHome());
     }
 
     private void setupUserHome() {

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerCommandRunner.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerCommandRunner.java
@@ -28,6 +28,7 @@ import org.moe.gradle.utils.Require;
 import org.moe.gradle.utils.TermColor;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 class ServerCommandRunner extends AbstractServerTask {
 
@@ -79,22 +80,16 @@ class ServerCommandRunner extends AbstractServerTask {
 
         try {
             channel.connect();
-        } catch (JSchException e) {
-            throw new GradleException(e.getMessage(), e);
-        }
-
-        while (!channel.isClosed()) {
-            try {
+            while (!channel.isClosed()) {
                 Thread.sleep(100);
-            } catch (InterruptedException e) {
-                throw new GradleException(e.getMessage(), e);
             }
+            output = baos.toString(StandardCharsets.UTF_8);
+        } catch (JSchException | InterruptedException e) {
+            throw new GradleException(e.getMessage(), e);
+        } finally {
+            channel.disconnect();
+            CloseableUtil.tryClose(baos, LOG, "Failed to close stream");
         }
-
-        output = baos.toString();
-        CloseableUtil.tryClose(baos, LOG, "Failed to close stream");
-
-        channel.disconnect();
         if (channel.getExitStatus() != 0) {
             throw new ServerChannelException("Remote command execution failed", output);
         }

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerFileUploader.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerFileUploader.java
@@ -88,6 +88,7 @@ class ServerFileUploader extends AbstractServerTask {
             outlog.flush();
 
             server.exec("unzip files", "unzip -o -d " + list.getTarget().getPath() + " " + serverPath);
+            Files.deleteIfExists(zipPath);
         } catch (IOException e) {
             throw new GradleException("Unable to create temporary zip file: " + e.getMessage());
         }

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerFileUploader.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerFileUploader.java
@@ -19,9 +19,11 @@ package org.moe.gradle.remote;
 import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.SftpException;
+import org.apache.tools.ant.types.selectors.SelectorUtils;
 import org.gradle.api.GradleException;
 import org.moe.gradle.anns.NotNull;
 import org.moe.gradle.remote.file.DirectoryEntry;
+import org.moe.gradle.remote.file.ExecPolicy;
 import org.moe.gradle.remote.file.FileEntry;
 import org.moe.gradle.remote.file.FileList;
 import org.moe.gradle.remote.file.Walker;
@@ -34,12 +36,21 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.moe.gradle.utils.TermColor.*;
 
 class ServerFileUploader extends AbstractServerTask {
+
+    private static final Set<PosixFilePermission> EXEC_PERMS = PosixFilePermissions.fromString("rwxr-xr-x");
+    private static final Set<PosixFilePermission> FILE_PERMS = PosixFilePermissions.fromString("rw-r--r--");
 
     @NotNull private final String name;
 
@@ -62,13 +73,26 @@ class ServerFileUploader extends AbstractServerTask {
         outlog.println(FG_SET_YELLOW + "    Remote: " + FG_SET_DEFAULT + list.getTarget().getPath());
         outlog.println();
 
+        boolean hostIsPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+        ExecPolicy policy = list.getExecPolicy();
+        List<String> globs;
+        if (hostIsPosix) {
+            globs = Collections.emptyList();
+        } else {
+            globs = switch (policy) {
+                case EXPLICIT -> server.getExecutablePathsSetting().stream().map(this::normalizeGlob).collect(Collectors.toList());
+                case ALL -> List.of("**");
+            };
+        }
+
         try {
             Path zipPath = Files.createTempFile("MOE-Remote", ".zip");
             Files.deleteIfExists(zipPath);
             Map<String, String> env = new HashMap<>();
             env.put("create", "true");
+            env.put("enablePosixFileAttributes", "true");
             try (FileSystem zipFile = FileSystems.newFileSystem(URI.create(zipPath.toUri().toString().replace("file://", "jar:file:")), env)) {
-                list.walk(new Zipper(zipFile));
+                list.walk(new Zipper(zipFile, hostIsPosix, globs));
                 Files.createFile(zipFile.getPath("/.placeholder"));
             }
 
@@ -94,6 +118,48 @@ class ServerFileUploader extends AbstractServerTask {
         }
     }
 
+    private void copyFileToZip(FileSystem zip, File local, Path remoteRel, Set<PosixFilePermission> perms) throws IOException {
+        Path parent = remoteRel.getParent();
+        if (parent != null) {
+            mkdirsInZip(zip, parent);
+        }
+        Path dst = zip.getPath(remoteRel.toString());
+        Files.copy(local.toPath(), dst);
+        Files.setPosixFilePermissions(dst, perms);
+    }
+
+    private void mkdirsInZip(FileSystem zip, Path remoteRelDir) throws IOException {
+        Path dir = zip.getPath(remoteRelDir.toString());
+        Files.createDirectories(dir);
+        for (Path p = dir; p != null && p.getNameCount() > 0; p = p.getParent()) {
+            Files.setPosixFilePermissions(p, EXEC_PERMS);
+        }
+    }
+
+    /**
+     * Pre-processes a user glob into the form Ant's {@link SelectorUtils#matchPath(String, String)} expects:
+     * separators folded to the host {@link File#separatorChar} (matchPath tokenizes on it),
+     * and a trailing separator expanded to {@code **}, the way Gradle's include/exclude does.
+     * Supports {@code **} (any incl. dirs), {@code *} (within a segment), {@code ?} (one char).
+     */
+    private String normalizeGlob(String glob) {
+        String p = glob.replace('/', File.separatorChar).replace('\\', File.separatorChar);
+        if (p.endsWith(File.separator))
+            p += "**";
+        return p;
+    }
+
+    /** Ant-style full-path match, case-sensitive (POSIX remote target). Empty list => no match. */
+    private boolean matchesAnyGlob(List<String> globs, String relPath) {
+        final String path = relPath.replace('/', File.separatorChar).replace('\\', File.separatorChar);
+        for (String g : globs) {
+            if (SelectorUtils.matchPath(g, path, true)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void uploadFile(String localPath, String remotePath) {
         try {
             ChannelSftp sftp = (ChannelSftp) server.session.openChannel("sftp");
@@ -109,33 +175,41 @@ class ServerFileUploader extends AbstractServerTask {
         private final StringBuilder structure = new StringBuilder(1024);
 
         private final FileSystem zipFile;
+        private final boolean hostIsPosix;
+        private final List<String> globs;
 
 
-        public Zipper(FileSystem zipFile) {
+        public Zipper(FileSystem zipFile, boolean hostIsPosix, List<String> globs) {
             this.zipFile = zipFile;
+            this.hostIsPosix = hostIsPosix;
+            this.globs = globs;
         }
 
         @Override
         public void visitFile(FileEntry entry, boolean isLast) throws IOException {
             outlog.print(structure + (isLast ? "\\-- " : "+-- ") + entry.getName());
             try {
-                @NotNull final File localFile = entry.getLocalFile();
-                if (localFile.length() > /* only check md5 when file if larger than */ 256 * 1024 && server.checkFileMD5(Server.getRemotePath(list.getTarget(), entry.getRemotePath()),
+                File localFile = entry.getLocalFile();
+                Path remoteRel = entry.getRemotePath();
+                if (localFile.length() > /* only check md5 when file if larger than */ 256 * 1024 && server.checkFileMD5(Server.getRemotePath(list.getTarget(), remoteRel),
                         localFile)) {
                     outlog.printf(" %s(up-to-date)%s\n", FG_SET_YELLOW, FG_SET_DEFAULT);
                     return;
                 }
 
-                if (entry.getRemotePath().getParent() != null) {
-                    Files.createDirectories(zipFile.getPath(entry.getRemotePath().getParent().toString()));
-                }
-
-                Files.copy(entry.getLocalFile().toPath(), zipFile.getPath(entry.getRemotePath().toString()));
+                copyFileToZip(zipFile, localFile, remoteRel, modeFor(localFile, remoteRel));
                 outlog.println();
             } catch (Exception e) {
                 outlog.println();
                 throw e;
             }
+        }
+
+        private Set<PosixFilePermission> modeFor(File localFile, Path remoteRel) throws IOException {
+            if (hostIsPosix)
+                return Files.getPosixFilePermissions(localFile.toPath());
+
+            return matchesAnyGlob(globs, remoteRel.toString()) ? EXEC_PERMS : FILE_PERMS;
         }
 
 

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerSettings.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerSettings.java
@@ -59,7 +59,7 @@ import java.util.function.Consumer;
 
 import static org.moe.gradle.utils.TermColor.*;
 
-class ServerSettings {
+public class ServerSettings {
 
     private static final Logger LOG = Logging.getLogger(ServerSettings.class);
 
@@ -223,7 +223,26 @@ class ServerSettings {
         return GraalVM.Companion.rootJDK(file).toFile();
     });
 
-    private static final Key<?>[] ALL_KEYS = new Key<?>[]{HOST_KEY, PORT_KEY, USER_KEY, KNOWNHOSTS_KEY, IDENTITY_KEY, AGENT_KEY, KEYCHAIN_NAME_KEY, KEYCHAIN_PASS_KEY, KEYCHAIN_LOCKTIMEOUT_KEY, GRAALVM_HOME_KEY};
+    private static final Key<List<String>> EXECUTABLE_PATHS_KEY = new Key<>("executablePaths",
+            "comma-separated glob patterns (relative to the project root) to force-mark executable on "
+                    + "the build server. Only used on windows host",
+            (plugin, value) -> {
+                if (value == null) {
+                    return null;
+                }
+                final List<String> out = new ArrayList<>();
+                for (String part : value.split(",")) {
+                    final String t = part.trim();
+                    if (!t.isEmpty()) {
+                        out.add(t);
+                    }
+                }
+                return out;
+            });
+
+    private static final Key<?>[] ALL_KEYS = new Key<?>[]{HOST_KEY, PORT_KEY, USER_KEY, KNOWNHOSTS_KEY,
+            IDENTITY_KEY, AGENT_KEY, KEYCHAIN_NAME_KEY, KEYCHAIN_PASS_KEY, KEYCHAIN_LOCKTIMEOUT_KEY, GRAALVM_HOME_KEY,
+            EXECUTABLE_PATHS_KEY};
 
     @NotNull
     private final Map<Key, Object> settings = new HashMap<>();
@@ -234,7 +253,7 @@ class ServerSettings {
     @NotNull
     private final MoePlugin plugin;
 
-    ServerSettings(@NotNull MoePlugin plugin) {
+    public ServerSettings(@NotNull MoePlugin plugin) {
         this.plugin = Require.nonNull(plugin);
 
         fillUnset();
@@ -321,7 +340,12 @@ class ServerSettings {
     }
 
     public boolean isConfigured() {
-        return get(HOST_KEY) != null;
+        return getHostKey() != null;
+    }
+
+    @Nullable
+    public String getHostKey() {
+        return get(HOST_KEY);
     }
 
     @NotNull
@@ -345,6 +369,12 @@ class ServerSettings {
     @Nullable
     public File getGraalVMHome() {
         return get(GRAALVM_HOME_KEY);
+    }
+
+    @NotNull
+    public List<String> getExecutablePaths() {
+        final List<String> v = get(EXECUTABLE_PATHS_KEY);
+        return v == null ? new ArrayList<>() : v;
     }
 
     public boolean isAgentEnabled() {

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerSettings.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerSettings.java
@@ -169,7 +169,7 @@ class ServerSettings {
 
     private static final Key<Boolean> AGENT_KEY = new Key<>("agent", "use the local ssh-agent (SSH_AUTH_SOCK) for authentication, defaults to false; mutually exclusive with identity", (plugin, value) -> {
         if (value == null) {
-            return false;
+            return null;
         }
         final String v = value.trim().toLowerCase();
         if (v.equals("true")) {

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerSettings.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerSettings.java
@@ -32,6 +32,7 @@ import org.moe.gradle.anns.Nullable;
 import org.moe.gradle.utils.FileUtils;
 import org.moe.gradle.utils.Require;
 import org.moe.gradle.utils.TermColor;
+import org.moe.tools.substrate.GraalVM;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Console;
@@ -41,6 +42,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -192,15 +195,19 @@ class ServerSettings {
         return i;
     });
 
-    private static final Key<String> GRADLE_REPOSITORIES_KEY = new Key<>("gradle.repositories", "repositories to be used when setting up the MOE SDK on the remote server, defaults to 'mavenCentral()'", (plugin, value) -> {
-        if (value == null) {
+    private static final Key<File> GRAALVM_HOME_KEY = new Key<>("graalvm.home", "path to a Java 25 GraalVM home on the host build server (required)", (plugin, value) -> {
+        if (value == null)
             return null;
-        }
-        return value;
+        Path file = Path.of(value);
+
+        if (!Files.exists(file) || !Files.isDirectory(file))
+            printWarning("'" + value + "' doesn't exist or is not a file");
+
+        return GraalVM.Companion.rootJDK(file).toFile();
     });
 
     private static final Key<?>[] ALL_KEYS = new Key<?>[]{HOST_KEY, PORT_KEY, USER_KEY, KNOWNHOSTS_KEY,
-            IDENTITY_KEY, KEYCHAIN_NAME_KEY, KEYCHAIN_PASS_KEY, KEYCHAIN_LOCKTIMEOUT_KEY, GRADLE_REPOSITORIES_KEY};
+            IDENTITY_KEY, KEYCHAIN_NAME_KEY, KEYCHAIN_PASS_KEY, KEYCHAIN_LOCKTIMEOUT_KEY, GRAALVM_HOME_KEY};
 
     @NotNull
     private final Map<Key, Object> settings = new HashMap<>();
@@ -319,10 +326,9 @@ class ServerSettings {
         return value == null ? 3600 : value;
     }
 
-    @NotNull
-    public String getGradleRepositories() {
-        final String value = get(GRADLE_REPOSITORIES_KEY);
-        return value == null ? "mavenCentral()" : value;
+    @Nullable
+    public File getGraalVMHome() {
+        return get(GRAALVM_HOME_KEY);
     }
 
     private static class OptionScreen {

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerSettings.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/ServerSettings.java
@@ -16,10 +16,13 @@ limitations under the License.
 
 package org.moe.gradle.remote;
 
+import com.jcraft.jsch.AgentIdentityRepository;
+import com.jcraft.jsch.AgentProxyException;
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import com.jcraft.jsch.SSHAgentConnector;
 import com.jcraft.jsch.UserInfo;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -164,6 +167,20 @@ class ServerSettings {
         return value;
     });
 
+    private static final Key<Boolean> AGENT_KEY = new Key<>("agent", "use the local ssh-agent (SSH_AUTH_SOCK) for authentication, defaults to false; mutually exclusive with identity", (plugin, value) -> {
+        if (value == null) {
+            return false;
+        }
+        final String v = value.trim().toLowerCase();
+        if (v.equals("true")) {
+            return true;
+        }
+        if (v.equals("false")) {
+            return false;
+        }
+        throw new IOException("'" + value + "' is not 'true' or 'false'");
+    });
+
     private static final Key<String> KEYCHAIN_NAME_KEY = new Key<>("keychain.name", "name of keychain to unlock, defaults to 'moeremotebuild.keychain'", (plugin, value) -> {
         if (value == null) {
             return null;
@@ -206,8 +223,7 @@ class ServerSettings {
         return GraalVM.Companion.rootJDK(file).toFile();
     });
 
-    private static final Key<?>[] ALL_KEYS = new Key<?>[]{HOST_KEY, PORT_KEY, USER_KEY, KNOWNHOSTS_KEY,
-            IDENTITY_KEY, KEYCHAIN_NAME_KEY, KEYCHAIN_PASS_KEY, KEYCHAIN_LOCKTIMEOUT_KEY, GRAALVM_HOME_KEY};
+    private static final Key<?>[] ALL_KEYS = new Key<?>[]{HOST_KEY, PORT_KEY, USER_KEY, KNOWNHOSTS_KEY, IDENTITY_KEY, AGENT_KEY, KEYCHAIN_NAME_KEY, KEYCHAIN_PASS_KEY, KEYCHAIN_LOCKTIMEOUT_KEY, GRAALVM_HOME_KEY};
 
     @NotNull
     private final Map<Key, Object> settings = new HashMap<>();
@@ -329,6 +345,27 @@ class ServerSettings {
     @Nullable
     public File getGraalVMHome() {
         return get(GRAALVM_HOME_KEY);
+    }
+
+    public boolean isAgentEnabled() {
+        final Boolean value = get(AGENT_KEY);
+        return value != null && value;
+    }
+
+    @Nullable
+    public String getIdentityKey() {
+        return get(IDENTITY_KEY);
+    }
+
+    @Nullable
+    public boolean hasIdentityKey() {
+        return getIdentityKey() != null;
+    }
+
+    private void assertSingleAuthMethod() throws JSchException {
+        if (isAgentEnabled() && hasIdentityKey()) {
+            throw new JSchException("Remote build: 'agent' and 'identity' are mutually exclusive — set only one.");
+        }
     }
 
     private static class OptionScreen {
@@ -568,8 +605,16 @@ class ServerSettings {
             jsch.setKnownHosts(file.getAbsolutePath());
         }
 
+        assertSingleAuthMethod();
+        final boolean agent = isAgentEnabled();
         final String identity = get(IDENTITY_KEY);
-        if (identity != null) {
+        if (agent) {
+            try {
+                jsch.setIdentityRepository(new AgentIdentityRepository(new SSHAgentConnector()));
+            } catch (AgentProxyException e) {
+                throw new JSchException("Failed to connect to ssh-agent: " + e.getMessage(), e);
+            }
+        } else if (identity != null) {
             final File file = getFileWithProperty(project, identity);
             jsch.addIdentity(file.getAbsolutePath());
         }

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/file/ExecPolicy.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/file/ExecPolicy.java
@@ -1,0 +1,34 @@
+/*
+Copyright (C) 2016 Migeran
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.moe.gradle.remote.file;
+
+/**
+ * Selects how UNIX executable permissions are handled on the remote build server for an upload.
+ * <p>
+ * On a POSIX driving host the real file modes are embedded directly into the zip and restored by
+ * the remote {@code unzip}, so this policy is <em>ignored</em> there — Unix just preserves the local
+ * exec bits. The policy only takes effect on a no-bit (Windows) driving host:
+ * <ul>
+ *   <li>{@link #EXPLICIT}: only files whose remote path matches a {@code moe.remotebuild.executablePaths}
+ *       glob are made executable. The default; used for the user's project tree.</li>
+ *   <li>{@link #ALL}: blanket {@code chmod -R +x <target>}. For the opaque MOE SDK / GraalVM trees.</li>
+ * </ul>
+ */
+public enum ExecPolicy {
+    EXPLICIT,
+    ALL
+}

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/file/FileList.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/remote/file/FileList.java
@@ -49,6 +49,9 @@ public class FileList implements EntryParent {
     @NotNull
     private final List<Entry> entries = new ArrayList<>();
 
+    @NotNull
+    private ExecPolicy execPolicy = ExecPolicy.EXPLICIT;
+
     public FileList(@NotNull File localRoot, @NotNull URI target) {
         this.localRoot = Require.nonNull(localRoot.getAbsoluteFile().toPath());
         this.target = Require.nonNull(target);
@@ -60,6 +63,15 @@ public class FileList implements EntryParent {
 
     public URI getTarget() {
         return target;
+    }
+
+    @NotNull
+    public ExecPolicy getExecPolicy() {
+        return execPolicy;
+    }
+
+    public void setExecPolicy(@NotNull ExecPolicy execPolicy) {
+        this.execPolicy = Require.nonNull(execPolicy);
     }
 
     public void walk(@NotNull Walker walker) {

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/tasks/R8.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/tasks/R8.java
@@ -295,7 +295,7 @@ public abstract class R8 extends AbstractBaseTask {
 
         composeConfigurationFile();
         ArrayList<String> args = new ArrayList<>(Arrays.asList(getR8Jar().getAbsolutePath(), "--output", getOutJar().getAbsolutePath()));
-        args.addAll(Arrays.asList("--pg-compat", "--classfile", "--lib", getMoePlugin().getGraalVM().getHome().toString(), "--pg-conf", getComposedCfgFile().getAbsolutePath()));
+        args.addAll(Arrays.asList("--pg-compat", "--classfile", "--lib", getMoePlugin().getGraalVM().getHome(), "--pg-conf", getComposedCfgFile().getAbsolutePath()));
         if (isDebugEnabled()) {
             args.add("--debug");
         } else {
@@ -303,7 +303,7 @@ public abstract class R8 extends AbstractBaseTask {
         }
 
         javaexec(spec -> {
-            spec.setExecutable(getMoePlugin().getGraalVM().getJavaPath().toFile().getAbsolutePath());
+            spec.setExecutable(getMoePlugin().getGraalVM().getJavaPath());
             if (GradleVersion.current().compareTo(GradleVersion.version("6.4")) >= 0) {
                 spec.getMainClass().set("com.android.tools.r8.R8");
             } else {

--- a/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/tasks/XcodeBuild.java
+++ b/tools/moe.plugin.gradle/src/main/java/org/moe/gradle/tasks/XcodeBuild.java
@@ -424,7 +424,7 @@ public abstract class XcodeBuild extends AbstractBaseTask {
 
                 final NativeImage nativeImageTask = xcodeProvider.getNativeImageTaskDep();
                 excludes.add(nativeImageTask.getLogFile());
-                excludes.add(resolvePathInBuildDir(nativeImageTask.getSvmTmpDir()));
+                excludes.add(nativeImageTask.getSvmTmpDir());
 
                 final ReflectionCollect reflectionCollectTask = nativeImageTask.getReflectionCollectTaskDep();
                 excludes.add(reflectionCollectTask.getOutputDir());

--- a/tools/moe.plugin.gradle/src/main/kotlin/org/moe/gradle/model/impl/GraalVMPropertiesImpl.kt
+++ b/tools/moe.plugin.gradle/src/main/kotlin/org/moe/gradle/model/impl/GraalVMPropertiesImpl.kt
@@ -10,7 +10,7 @@ data class GraalVMPropertiesImpl(
     override val jdkVersion: JDKVersion
 ) : GraalVMProperties, Serializable {
     constructor(graalVM: GraalVM) : this(
-        home = graalVM.home.toAbsolutePath().toString(),
+        home = graalVM.home,
         jdkVersion = graalVM.version,
     )
 }

--- a/tools/moe.plugin.gradle/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
+++ b/tools/moe.plugin.gradle/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
@@ -1,7 +1,9 @@
 package org.moe.gradle.tasks
 
+import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
@@ -14,9 +16,12 @@ import org.moe.gradle.anns.IgnoreUnused
 import org.moe.gradle.anns.NotNull
 import org.moe.gradle.anns.Nullable
 import org.moe.gradle.options.ProGuardOptions
+import org.moe.gradle.remote.Server
+import org.moe.gradle.remote.file.FileList
 import org.moe.gradle.utils.Arch
 import org.moe.gradle.utils.GradleCompatUtils
 import org.moe.gradle.utils.Mode
+import org.moe.tools.substrate.CompileResult
 import org.moe.tools.substrate.Config
 import org.moe.tools.substrate.SubstrateExecutor
 import org.moe.tools.substrate.Triplet
@@ -29,10 +34,12 @@ abstract class NativeImage : AbstractBaseTask() {
 
     private var inputFiles: Set<Any>? = null
 
-    @Input
+    @InputDirectory
     @NotNull
-    fun getGvmHomePath(): String {
-        return moePlugin.graalVM.home.toString()
+    fun getGvmHomePath(): File {
+        val remote = moePlugin.remoteServer ?: return File(moePlugin.graalVM.base)
+        return remote.graalVMHomeSetting
+                ?: throw GradleException("Remote build requires 'moe.remotebuild.graalvm.home' to point at a GraalVM home for the remote build.")
     }
 
     @InputFiles
@@ -212,12 +219,17 @@ abstract class NativeImage : AbstractBaseTask() {
                 outputDir = getSvmTmpDir().toPath(),
                 logFile = logFile,
         )
+        val remoteServer = moePlugin.remoteServer
         val executor = SubstrateExecutor(
-                graalVM = moePlugin.graalVM,
-                config = svmConf
+                graalVM = if (remoteServer != null) remoteServer.remoteGraalVM else moePlugin.graalVM,
+                config = svmConf,
         )
-        val result = executor.compile()
 
+        val result = if (remoteServer != null) runRemote(remoteServer, svmConf, executor) else executor.compile()
+        moveResults(svmConf, result)
+    }
+
+    private fun moveResults(svmConf: Config, result: CompileResult) {
         // Move generated object files to a fixed position, so they can be found by Xcode
         Files.move(result.mainObj, getMainObjFile().toPath(), StandardCopyOption.REPLACE_EXISTING)
         if (svmConf.useLLVM) {
@@ -232,6 +244,47 @@ abstract class NativeImage : AbstractBaseTask() {
             getJDWPMetadataFile().delete()
         }
     }
+
+    /**
+     * Run native-image on the remote macOS build server: upload the inputs + CAP cache, invoke
+     * native-image over SSH with every path translated to its remote equivalent, then download the build dir.
+     */
+    private fun runRemote(remoteServer: Server, svmConf: Config, executor: SubstrateExecutor): CompileResult {
+        val rootProjectDir = project.rootDir
+        val sdkRoot = moeSDK.root.toPath().toAbsolutePath()
+
+        fun isSdkFile(f: File): Boolean = f.toPath().toAbsolutePath().startsWith(sdkRoot)
+        fun remotePathFor(f: File): String =
+                if (isSdkFile(f)) remoteServer.getSDKRemotePath(f)
+                else remoteServer.getRemotePath(getInnerProjectRelativePath(f.absoluteFile))
+
+        executor.clearOutputDir()
+        val capLocal = executor.ensureCapCacheDir()
+
+        val list = FileList(rootProjectDir, remoteServer.buildDir)
+        val inputs = svmConf.classpath + svmConf.resourceConfigFile + svmConf.jniConfigFiles +
+                svmConf.reflectionConfigFiles + svmConf.proxyConfigFiles + setOf(capLocal.toFile())
+        inputs.filterNot { isSdkFile(it) }.forEach { list.add(it.absoluteFile) }
+        remoteServer.upload("native-image inputs", list)
+
+        val capRemote = remotePathFor(capLocal.toFile())
+        val tmpRemote = remotePathFor(svmConf.outputDir.toFile())
+        val args = executor.buildArgs(
+                capDir = capRemote,
+                tmpDir = tmpRemote,
+                resolve = { remotePathFor(File(it)) },
+        )
+        val nativeImage = remoteServer.remoteGraalVM.nativeImage
+        remoteServer.exec("native-image", "mkdir -p ${shellQuote(tmpRemote)} && cd ${shellQuote(tmpRemote)} && " +
+                shellQuote(nativeImage) + " " + args.joinToString(" ") { shellQuote(it) })
+
+        executor.clearOutputDir()
+        remoteServer.downloadDirectory("native-image output", tmpRemote, svmConf.outputDir.toFile())
+
+        return executor.locateOutputs()
+    }
+
+    private fun shellQuote(s: String): String = "'" + s.replace("'", "'\\''") + "'"
 
     @get:Internal
     lateinit var r8TaskDep: R8
@@ -257,7 +310,7 @@ abstract class NativeImage : AbstractBaseTask() {
             @NotNull arch: Arch,
             @NotNull platform: MoePlatform
     ) {
-        setSupportsRemoteBuild(false)
+        setSupportsRemoteBuild(true)
 
         // Construct default output path
         val outRoot = Paths.get(MoePlugin.MOE, sourceSet.name, "native_image")

--- a/tools/moe.plugin.gradle/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
+++ b/tools/moe.plugin.gradle/src/main/kotlin/org/moe/gradle/tasks/NativeImage.kt
@@ -2,13 +2,7 @@ package org.moe.gradle.tasks
 
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.*
 import org.gradle.api.tasks.bundling.Jar
 import org.moe.gradle.MoePlatform
 import org.moe.gradle.MoePlugin
@@ -198,6 +192,7 @@ abstract class NativeImage : AbstractBaseTask() {
     fun isEnableJDWP(): Boolean = mode == Mode.DEBUG
 
     override fun run() {
+        moePlugin.requireMacHostOrRemoteServerConfig(this)
         val svmConf = Config(
                 mainClassName = getMainClassName(),
                 classpath = getInputFiles().toSet()

--- a/tools/moe.plugin.gradle/src/test/java/org/moe/gradle/MinGradleSupportTest.java
+++ b/tools/moe.plugin.gradle/src/test/java/org/moe/gradle/MinGradleSupportTest.java
@@ -8,14 +8,14 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class MinGradleSupportTest extends AbstractPluginTest {
 
     @Test
     public void testPluginApplyMinGradle() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
+        File props = testProjectDir.newFile("gradle.properties");
 
         // @formatter:off
         String buildFileContent = "plugins {\n" +
@@ -24,6 +24,11 @@ public class MinGradleSupportTest extends AbstractPluginTest {
                 "}";
         // @formatter:on
         writeFile(buildFile, buildFileContent);
+
+        String oldJdk = System.getProperty("moe.test.java_home");
+        assertNotNull("min-gradle test needs a JDK <= 19", oldJdk);
+
+        writeFile(props, "org.gradle.java.home=" + oldJdk.replace("\\", "/") + "\n");
 
         BuildResult result = GradleRunner.create()
                 .withGradleVersion(AbstractMoePlugin.getGradleMinVersion())

--- a/tools/moe.plugin.gradle/src/test/java/org/moe/gradle/UIActionsAndOutletsTest.java
+++ b/tools/moe.plugin.gradle/src/test/java/org/moe/gradle/UIActionsAndOutletsTest.java
@@ -65,18 +65,19 @@ public class UIActionsAndOutletsTest extends AbstractPluginTest {
         gradleBuilder.append("moe.actionsAndOutlets.include 'org\\\\.moe\\\\.UnmappedController'\n");
         gradleBuilder.append("moe.actionsAndOutlets.include 'org\\\\.moe\\\\.ValidController'\n");
         gradleBuilder.append("moe.actionsAndOutlets.excludeLibrary 'AVFoundation'\n");
+        gradleBuilder.append("moe.actionsAndOutlets.excludeLibrary 'AVFAudio'\n");
         gradleBuilder.append("moe.actionsAndOutlets.additionalCode '#warning This is my additional code!'\n");
         FileUtils.write(buildGradleFile, gradleBuilder.toString());
 
         BuildResult result = GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
-                .withArguments("moeGenerateUIObjCInterfaces", "-Pmoe.sdk.localbuild=" + getSdkLocalbuild(), "-s")
+                .withArguments("moeDebugGenerateUIObjCInterfaces", "-Pmoe.sdk.localbuild=" + getSdkLocalbuild(), "-s")
                 .withPluginClasspath(getPluginClasspath())
                 .build();
 
         final String output = result.getOutput();
         assertTrue(output.contains("moe"));
-        assertEquals(result.task(":moeGenerateUIObjCInterfaces").getOutcome(), SUCCESS);
+        assertEquals(result.task(":moeDebugGenerateUIObjCInterfaces").getOutcome(), SUCCESS);
 
         assertTrue(output.contains(
                 "Skipping org.moe.InvalidController: superclass (org.moe.UnmappedController) is not mapped to Objective-C"));

--- a/tools/moe.plugin.gradle/src/test/java/org/moe/gradle/remote/Ed25519KeySupportTest.java
+++ b/tools/moe.plugin.gradle/src/test/java/org/moe/gradle/remote/Ed25519KeySupportTest.java
@@ -1,0 +1,47 @@
+package org.moe.gradle.remote;
+
+import com.jcraft.jsch.JSch;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeNoException;
+
+/**
+ * Verifies the SSH library can load an OpenSSH-format ed25519 private key.
+ * com.jcraft:jsch 0.1.53 throws JSchException("invalid privatekey") here;
+ * com.github.mwiede:jsch 2.28.2 parses it.
+ */
+public class Ed25519KeySupportTest {
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void loadsOpenSshEd25519Key() throws Exception {
+        final File key = new File(tmp.getRoot(), "id_ed25519");
+
+        final Process p;
+        try {
+            p = new ProcessBuilder(
+                    "ssh-keygen", "-t", "ed25519", "-N", "", "-C", "moe-test",
+                    "-f", key.getAbsolutePath())
+                    .redirectErrorStream(true)
+                    .start();
+        } catch (IOException notOnPath) {
+            assumeNoException("ssh-keygen unavailable; skipping", notOnPath);
+            return;
+        }
+
+        String output = new String(p.getInputStream().readAllBytes());
+        int code = p.waitFor();
+        assertEquals("ssh-keygen failed: " + output, 0, code);
+
+        new JSch().addIdentity(key.getAbsolutePath());
+    }
+}

--- a/tools/moe.plugin.gradle/src/test/resources/ui-actions-and-outlets/ValidController.java
+++ b/tools/moe.plugin.gradle/src/test/resources/ui-actions-and-outlets/ValidController.java
@@ -17,7 +17,7 @@ limitations under the License.
 package org.moe;
 
 import apple.NSObject;
-import apple.avfoundation.protocol.AVAudioPlayerDelegate;
+import apple.avfaudio.protocol.AVAudioPlayerDelegate;
 import apple.uikit.UIEvent;
 import apple.uikit.UILabel;
 import apple.uikit.UIViewController;

--- a/tools/moe.tools.substrate/src/main/kotlin/org/moe/tools/substrate/GraalVM.kt
+++ b/tools/moe.tools.substrate/src/main/kotlin/org/moe/tools/substrate/GraalVM.kt
@@ -1,52 +1,36 @@
 package org.moe.tools.substrate
 
-import org.moe.common.exec.ExecOutputCollector
-import org.moe.common.exec.SimpleExec
-import org.moe.common.utils.OsUtils
-import org.moe.tools.substrate.utils.findByExt
 import org.slf4j.LoggerFactory
 import java.io.IOException
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
-/**
- * @property home path to the GraalVM home
- */
 class GraalVM(
-        val home: Path
+        val base: String,
+        val host: GraalVMHost,
 ) {
-
-    val javaPath: Path
-    val bin: Path
-    val nativeImage: Path
+    val home = if (host.exists(host.resolve(base, "Contents", "Home"))) host.resolve(base, "Contents", "Home") else base
+    val bin: String = host.resolve(home, "bin")
+    val javaPath: String = host.resolve(bin, "java")
+    val nativeImage: String = host.resolve(bin, if (host.isWindows) "native-image.cmd" else "native-image")
     val version: JDKVersion
 
     init {
-        if (!Files.exists(home)) {
+        if (!host.exists(home)) {
             throw IOException("GraalVM home not exist: $home")
         }
-        bin = home.resolve("bin")
-        if (!Files.exists(bin)) {
+        if (!host.exists(bin)) {
             throw IOException("GraalVM home doesn't contain the bin directory: $home")
         }
-
-        javaPath = bin.resolve("java")
-        if (!Files.exists(javaPath)) {
+        if (!host.exists(javaPath)) {
             throw IOException("GraalVM bin/java does not exist: $javaPath")
         }
 
-        if (OsUtils.isWindows()) {
-            nativeImage = bin.resolve("native-image.cmd")
-        } else {
-            nativeImage = bin.resolve("native-image")
+        if (host.isMac) {
+            host.ensureUnquarantined(base)
         }
 
-        if (OsUtils.isMac()) {
-            checkQuarantine()
-        }
-
-        version = parseVMVersion()
+        version = parseVMVersion(host.exec(javaPath, "-version"))
         println("Using GraalVM $version at $home")
 
         require (version.feature == SUPPORTED_JAVA_MAJOR) {
@@ -62,52 +46,20 @@ class GraalVM(
         }
     }
 
-    private fun parseVMVersion(): JDKVersion {
-        val versionOut = ExecOutputCollector.collect(
-                SimpleExec
-                        .getExec(bin.resolve("java"), "-version")
-                        .runner
-                        // Not sure why java output version in stderr...
-                        .apply { builder.redirectErrorStream(true) }
-        ).trim()
-
-        val jdkVersion = "openjdk version \"([0-9._]+)\"".toPattern().matcher(versionOut).let {
+    fun parseVMVersion(versionOutput: String): JDKVersion =
+        "openjdk version \"([0-9._]+)\"".toPattern().matcher(versionOutput).let {
             if (!it.find()) {
-                throw IllegalStateException("Cannot determine the JDK version from $versionOut")
+                throw IllegalStateException("Cannot determine the JDK version from $versionOutput")
             }
             JDKVersion.parse(it.group(1))
         }
 
-        return jdkVersion
-    }
 
     /**
      * Make sure the llvm-toolchain is installed
      */
     fun ensureLLVM() {
         throw IOException("The LLVM-Backend is currently unsupported")
-    }
-
-    /**
-     * Check if the GraalVM files have [MAC_ATTR_COM_APPLE_QUARANTINE] attr.
-     */
-    private fun checkQuarantine() {
-        val root = if (home.endsWith(Paths.get("Contents", "Home"))) {
-            home.parent.parent
-        } else {
-            home
-        }.toAbsolutePath()
-
-        LOG.debug("Checking quarantine of {}", root)
-
-        val attrs = SimpleExec.exec("xattr", root.toString()).trim().lines()
-        if (MAC_ATTR_COM_APPLE_QUARANTINE in attrs) {
-            LOG.warn(
-                "GraalVM home quarantined, run the following command to remove the quarantine attribute:\nsudo xattr -r -d {} {}",
-                MAC_ATTR_COM_APPLE_QUARANTINE, root
-            )
-            throw IllegalArgumentException("GraalVM home quarantined")
-        }
     }
 
     data class JDKVersion(
@@ -198,9 +150,16 @@ class GraalVM(
     companion object {
         private val LOG = LoggerFactory.getLogger(GraalVM::class.java)
 
-        private const val MAC_ATTR_COM_APPLE_QUARANTINE = "com.apple.quarantine"
+        const val MAC_ATTR_COM_APPLE_QUARANTINE = "com.apple.quarantine"
 
         const val SUPPORTED_JAVA_MAJOR = 25
+
+        fun Path.rootJDK(): Path {
+            if (endsWith(Paths.get("Contents", "Home")))
+                return parent.parent
+
+            return this
+        }
 
         private fun List<String>.parseComponent(index: Int): Int = getOrNull(index)?.toInt() ?: 0
 

--- a/tools/moe.tools.substrate/src/main/kotlin/org/moe/tools/substrate/GraalVMHost.kt
+++ b/tools/moe.tools.substrate/src/main/kotlin/org/moe/tools/substrate/GraalVMHost.kt
@@ -1,0 +1,31 @@
+package org.moe.tools.substrate
+
+/**
+ * Abstracts the machine a [GraalVM] lives on, so the same [GraalVM] logic works for the local host
+ * and a remote (SSH) build server. Every environment-specific operation a [GraalVM] needs goes
+ * through this handler; a [GraalVM] holds no [java.nio.file.Path] (which would implicitly mean "the
+ * local JVM's filesystem").
+ */
+interface GraalVMHost {
+
+    val isWindows: Boolean
+
+    val isMac: Boolean
+
+    /** Compose a path in this machine's convention (local separator vs. remote `/`). */
+    fun resolve(base: String, vararg parts: String): String
+
+    fun exists(path: String): Boolean
+
+    /** Run [command] on this machine and return its combined stdout+stderr, trimmed. */
+    fun exec(vararg command: String): String
+
+    /**
+     * Ensure the GraalVM at [base] is not Gatekeeper-quarantined. Policy is per-machine: the local
+     * host detects and throws with a fix instruction; a remote build server clears it automatically.
+     * Only invoked when [isMac] is true.
+     */
+    fun ensureUnquarantined(base: String)
+
+    val pathSeparator: String get() = if (isWindows) ";" else ":"
+}

--- a/tools/moe.tools.substrate/src/main/kotlin/org/moe/tools/substrate/LocalGraalVMHost.kt
+++ b/tools/moe.tools.substrate/src/main/kotlin/org/moe/tools/substrate/LocalGraalVMHost.kt
@@ -1,0 +1,54 @@
+package org.moe.tools.substrate
+
+import org.apache.commons.io.FilenameUtils
+import org.moe.common.exec.ExecOutputCollector
+import org.moe.common.exec.SimpleExec
+import org.moe.common.utils.OsUtils
+import org.moe.tools.substrate.GraalVM.Companion.MAC_ATTR_COM_APPLE_QUARANTINE
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * [GraalVMHost] for the local machine — the behavior [GraalVM] used to do inline
+ * (OsUtils / Files / SimpleExec), now living behind the handler seam.
+ */
+class LocalGraalVMHost : GraalVMHost {
+
+    override val isWindows: Boolean
+        get() = OsUtils.isWindows()
+
+    override val isMac: Boolean
+        get() = OsUtils.isMac()
+
+    override fun resolve(base: String, vararg parts: String): String =
+            parts.fold(base) { acc, part -> FilenameUtils.concat(acc, part) }
+
+    override fun exists(path: String): Boolean = Files.exists(Paths.get(path))
+
+    override fun exec(vararg command: String): String =
+            ExecOutputCollector.collect(
+                    SimpleExec
+                            .getExec(command.first(), *command.drop(1).toTypedArray())
+                            .runner
+                            // java writes -version to stderr
+                            .apply { builder.redirectErrorStream(true) }
+            ).trim()
+
+    override fun ensureUnquarantined(base: String) {
+        LOG.debug("Checking quarantine of {}", base)
+
+        val attrs = SimpleExec.exec("xattr", base).trim().lines()
+        if (MAC_ATTR_COM_APPLE_QUARANTINE in attrs) {
+            LOG.warn(
+                    "GraalVM home quarantined, run the following command to remove the quarantine attribute:\nsudo xattr -r -d {} {}",
+                    MAC_ATTR_COM_APPLE_QUARANTINE, base
+            )
+            throw IllegalArgumentException("GraalVM home quarantined")
+        }
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(LocalGraalVMHost::class.java)
+    }
+}

--- a/tools/moe.tools.substrate/src/main/kotlin/org/moe/tools/substrate/SubstrateExecutor.kt
+++ b/tools/moe.tools.substrate/src/main/kotlin/org/moe/tools/substrate/SubstrateExecutor.kt
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 
 data class CompileResult(
     val mainObj: Path,
@@ -19,6 +20,11 @@ class SubstrateExecutor(
         val graalVM: GraalVM,
         val config: Config,
 ) {
+
+    /** Maps a host absolute path to the path that should appear in the native-image command. */
+    fun interface PathResolver {
+        fun resolve(path: String): String
+    }
 
     /**
      * Compile the java classes into native object, using
@@ -37,71 +43,24 @@ class SubstrateExecutor(
         }
 
         // Run the native-image command
-        SimpleExec.getExec(
-                graalVM.nativeImage,
-                "-H:+SharedLibrary",
+        val args = buildArgs(
+                capDir = ensureCapCacheDir().toString(),
+                tmpDir = config.outputDir.toAbsolutePath().toString(),
+                resolve = { it },
+        )
+        SimpleExec.getExec(graalVM.nativeImage, *args.toTypedArray())
+                .apply { workingDir = config.outputDir.toFile() }
+                .collect(logFile = config.logFile)
 
-                // iOS specific flags
-                "-H:PageSize=16384",
+        return locateOutputs()
+    }
 
-                // Common args
-                "-Djdk.internal.lambda.eagerlyInitialize=false",
-                "-Djdk.internal.foreign.CABI=${config.target.toCABI()}",
-                "-H:-DeadlockWatchdogExitOnTimeout",
-                "-H:DeadlockWatchdogInterval=0",
-                "-H:+ExitAfterRelocatableImageWrite",
-                "-H:+IncludeAllLocales", // Make sure all locales are available at runtime
-                *argsIf(config.useLLVM, "-H:CompilerBackend=llvm"),
-
-                // Build info
-                "--initialize-at-build-time=org.moe.core.MOE\$Build",
-                "-Dsvm.targetName=iOS",
-                "-Dsvm.targetArch=${config.target.arch}",
-                "-Dsvm.platform=org.graalvm.nativeimage.Platform\$${config.target.toSVMPlatform()}",
-                "-Dmoe.debug=${config.debug}",
-                "-Dmoe.platform.name=${config.target.os}",
-
-                "-H:TempDirectory=${config.outputDir.toAbsolutePath()}",
-                "-H:+UseCAPCache",
-                "-H:CAPCacheDir=${ensureCapCacheDir()}",
-                "--no-server",
-
-                // We don't need isolates
-                *argsIf(!config.enableJDWP, "-H:-SpawnIsolates"),
-                *argsIf(config.enableJDWP, "-H:+JDWP", "-H:-CopyNativeJDWPLibrary", "-H:+SpawnIsolates", "-R:ReservedAddressSpaceSize=536870912"),
-
-                *config.customOptions.toTypedArray(),
-
-                // Resource configs
-                // "-H:Log=registerResource:verbose",
-                *config.resourceConfigFile.map {
-                    "-H:ResourceConfigurationFiles=${it.absolutePath}"
-                }.toTypedArray(),
-
-                // Reflection & JNI configs
-                *config.jniConfigFiles.map {
-                    "-H:JNIConfigurationFiles=${it.absolutePath}"
-                }.toTypedArray(),
-                *config.reflectionConfigFiles.map {
-                    "-H:ReflectionConfigurationFiles=${it.absolutePath}"
-                }.toTypedArray(),
-                *config.proxyConfigFiles.map {
-                    "-H:DynamicProxyConfigurationFiles=${it.absolutePath}"
-                }.toTypedArray(),
-                "-H:+AllowIncompleteClasspath",
-
-                "-cp",
-                config.classpath.joinToString(File.pathSeparator),
-                config.mainClassName,
-        ).apply {
-            workingDir = config.outputDir.toFile()
-        }.collect(logFile = config.logFile)
-
+    fun locateOutputs(): CompileResult {
         // Now checking the result
         val mainObj = config.outputDir.findOne(
-                fileName = "${config.mainClassName.lowercase()}.o",
-                isDirectory = false,
-                maxDepth = 5,
+            fileName = mainObjFileName(),
+            isDirectory = false,
+            maxDepth = 5,
         )
         println("Main object file: $mainObj")
 
@@ -120,7 +79,7 @@ class SubstrateExecutor(
         val metadata: Path?
         if (config.enableJDWP) {
             metadata = config.outputDir.findOne(
-                fileName = "${config.mainClassName.lowercase()}.dylib.metadata",
+                fileName = jdwpMetadataFileName(),
                 isDirectory = false,
                 maxDepth = 5,
             )
@@ -136,12 +95,82 @@ class SubstrateExecutor(
         )
     }
 
-    private fun clearOutputDir() {
+    fun buildArgs(
+            capDir: String,
+            tmpDir: String,
+            resolve: PathResolver,
+    ): List<String> {
+        val args = mutableListOf(
+                "-H:+SharedLibrary",
+
+                // iOS specific flags
+                "-H:PageSize=16384",
+
+                // Common args
+                "-Djdk.internal.lambda.eagerlyInitialize=false",
+                "-Djdk.internal.foreign.CABI=${config.target.toCABI()}",
+                "-H:-DeadlockWatchdogExitOnTimeout",
+                "-H:DeadlockWatchdogInterval=0",
+                "-H:+ExitAfterRelocatableImageWrite",
+                "-H:+IncludeAllLocales", // Make sure all locales are available at runtime
+        )
+        if (config.useLLVM) {
+            args += "-H:CompilerBackend=llvm"
+        }
+        args += listOf(
+                // Build info
+                "--initialize-at-build-time=org.moe.core.MOE\$Build",
+                "-Dsvm.targetName=iOS",
+                "-Dsvm.targetArch=${config.target.arch}",
+                "-Dsvm.platform=org.graalvm.nativeimage.Platform\$${config.target.toSVMPlatform()}",
+                "-Dmoe.debug=${config.debug}",
+                "-Dmoe.platform.name=${config.target.os}",
+
+                "-H:TempDirectory=$tmpDir",
+                "-H:+UseCAPCache",
+                "-H:CAPCacheDir=$capDir",
+                "--no-server",
+        )
+
+        // We don't need isolates
+        if (!config.enableJDWP) {
+            args += "-H:-SpawnIsolates"
+        }
+        if (config.enableJDWP) {
+            args += listOf("-H:+JDWP", "-H:-CopyNativeJDWPLibrary", "-H:+SpawnIsolates", "-R:ReservedAddressSpaceSize=536870912")
+        }
+
+        args += config.customOptions
+
+        // Resource configs
+        args += config.resourceConfigFile.map { "-H:ResourceConfigurationFiles=${resolve.resolve(it.absolutePath)}" }
+
+        // Reflection & JNI configs
+        args += config.jniConfigFiles.map { "-H:JNIConfigurationFiles=${resolve.resolve(it.absolutePath)}" }
+        args += config.reflectionConfigFiles.map { "-H:ReflectionConfigurationFiles=${resolve.resolve(it.absolutePath)}" }
+        args += config.proxyConfigFiles.map { "-H:DynamicProxyConfigurationFiles=${resolve.resolve(it.absolutePath)}" }
+        args += "-H:+AllowIncompleteClasspath"
+
+        val classpath = config.classpath.joinToString(graalVM.host.pathSeparator) {
+            resolve.resolve(it.absolutePath)
+        }
+
+        args += listOf("-cp", classpath, config.mainClassName)
+        return args
+    }
+
+    /** Name of the SVM main object file (inside a timestamped sub-dir of the output dir). */
+    fun mainObjFileName(): String = "${config.mainClassName.lowercase()}.o"
+
+    /** Name of the SVM JDWP metadata file. */
+    fun jdwpMetadataFileName(): String = "${config.mainClassName.lowercase()}.dylib.metadata"
+
+    fun clearOutputDir() {
         FileUtils.deleteDirectory(config.outputDir.toFile())
         Files.createDirectories(config.outputDir)
     }
 
-    private fun ensureCapCacheDir(): Path {
+    fun ensureCapCacheDir(): Path {
         val capPath = config.outputDir.resolve("capcache")
         if (!Files.exists(capPath)) {
             Files.createDirectories(capPath)
@@ -149,7 +178,7 @@ class SubstrateExecutor(
 
         CAP_CACHES.forEach {
             javaClass.classLoader.getResourceAsStream("cap_${config.target.arch}/$it").use { input ->
-                Files.copy(input, capPath.resolve(it))
+                Files.copy(input!!, capPath.resolve(it))
             }
         }
 
@@ -189,12 +218,6 @@ class SubstrateExecutor(
             Triplet.IPHONESIMULATOR_AMD64 -> "SYS_V"
 
             else -> throw IllegalArgumentException("Target not supported: $this")
-        }
-
-        private fun argsIf(condition: Boolean, vararg args: String): Array<out String> = if (condition) {
-            args
-        } else {
-            emptyArray()
         }
 
     }


### PR DESCRIPTION
- Make native-image build on remote host
- Update jsch to 2.28.2
- Add ssh agent support
- Bump JVM target to 17 and gradle to 7.6.4 (previous versions have bugs with multi-release jars)
- Properly retain file permissions on unix maschines, add better way to configure exec perms on win host
- 